### PR TITLE
Mod fixes for indicators

### DIFF
--- a/indicators/indicators.c
+++ b/indicators/indicators.c
@@ -34,7 +34,7 @@ bool draw_indicators(uint8_t led_min, uint8_t led_max) {
 #endif // NO_ACTION_ONESHOT
 
     indicator_fn_args_t args = {
-        .mods  = mods,
+        .mods  = mod_config(mods),
         .layer = layer,
     };
 

--- a/indicators/indicators.c
+++ b/indicators/indicators.c
@@ -25,6 +25,43 @@ static bool should_draw_indicator(const indicator_t *indicator, const indicator_
     return true;
 }
 
+static uint8_t mod_config_8bit(uint8_t mod) {
+    if (keymap_config.swap_lalt_lgui) {
+        /** If both modifiers pressed or neither pressed, do nothing
+         * Otherwise swap the values
+         */
+        if (((mod & MOD_BIT(KC_LALT)) && !(mod & MOD_BIT(KC_LGUI))) ||
+            (!(mod & MOD_BIT(KC_LALT)) && (mod & MOD_BIT(KC_LGUI)))) {
+            mod ^= (MOD_BIT(KC_LALT) | MOD_BIT(KC_LGUI));
+        }
+    }
+    if (keymap_config.swap_ralt_rgui) {
+        if (((mod & MOD_BIT(KC_RALT)) && !(mod & MOD_BIT(KC_RGUI))) ||
+            (!(mod & MOD_BIT(KC_RALT)) && (mod & MOD_BIT(KC_RGUI)))) {
+            mod ^= (MOD_BIT(KC_RALT) | MOD_BIT(KC_RGUI));
+        }
+    }
+    if (keymap_config.swap_lctl_lgui) {
+        if (((mod & MOD_BIT(KC_LCTL)) && !(mod & MOD_BIT(KC_LGUI))) ||
+            (!(mod & MOD_BIT(KC_LCTL)) && (mod & MOD_BIT(KC_LGUI)))) {
+            mod ^= (MOD_BIT(KC_LCTL) | MOD_BIT(KC_LGUI));
+        }
+    }
+    if (keymap_config.swap_rctl_rgui) {
+        if (((mod & MOD_BIT(KC_RCTL)) && !(mod & MOD_BIT(KC_RGUI))) ||
+            (!(mod & MOD_BIT(KC_RCTL)) && (mod & MOD_BIT(KC_RGUI)))) {
+            mod ^= (MOD_BIT(KC_RCTL) | MOD_BIT(KC_RGUI));
+        }
+    }
+    if (keymap_config.no_gui) {
+        mod &= ~MOD_BIT(KC_LGUI);
+        mod &= ~MOD_BIT(KC_RGUI);
+    }
+
+    return mod;
+}
+
+
 bool draw_indicators(uint8_t led_min, uint8_t led_max) {
     uint8_t mods  = get_mods();
     uint8_t layer = get_highest_layer(layer_state);
@@ -34,7 +71,7 @@ bool draw_indicators(uint8_t led_min, uint8_t led_max) {
 #endif
 
     indicator_fn_args_t args = {
-        .mods  = mods,
+        .mods  = mod_config_8bit(mods),
         .layer = layer,
     };
 

--- a/indicators/indicators.c
+++ b/indicators/indicators.c
@@ -31,7 +31,7 @@ bool draw_indicators(uint8_t led_min, uint8_t led_max) {
 
 #ifndef NO_ACTION_ONESHOT
     mods |= get_oneshot_mods();
-#endif // NO_ACTION_ONESHOT
+#endif
 
     indicator_fn_args_t args = {
         .mods  = mods,

--- a/indicators/indicators.c
+++ b/indicators/indicators.c
@@ -29,6 +29,10 @@ bool draw_indicators(uint8_t led_min, uint8_t led_max) {
     uint8_t mods  = get_mods();
     uint8_t layer = get_highest_layer(layer_state);
 
+#ifndef NO_ACTION_ONESHOT
+    mods |= get_oneshot_mods();
+#endif // NO_ACTION_ONESHOT
+
     indicator_fn_args_t args = {
         .mods  = mods,
         .layer = layer,

--- a/indicators/indicators.c
+++ b/indicators/indicators.c
@@ -34,7 +34,7 @@ bool draw_indicators(uint8_t led_min, uint8_t led_max) {
 #endif // NO_ACTION_ONESHOT
 
     indicator_fn_args_t args = {
-        .mods  = mod_config(mods),
+        .mods  = mods,
         .layer = layer,
     };
 


### PR DESCRIPTION
checks oneshot mods too, if not disabled.  ~~And swaps mods based on magic config.~~ (not now, because it only works for 5-bit packed mods)

Fixes #3